### PR TITLE
feat/create-locale-setting-role

### DIFF
--- a/playbook_set_locale.yml
+++ b/playbook_set_locale.yml
@@ -1,0 +1,5 @@
+---
+- name: Locale Settings
+  hosts: all
+  roles:
+    - set_locale

--- a/roles/set_locale/tasks/main.yml
+++ b/roles/set_locale/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Include pre_check tasks
+  ansible.builtin.include_tasks: pre_check.yml
+
+- name: Include main tasks
+  ansible.builtin.include_tasks: set_locale.yml

--- a/roles/set_locale/tasks/pre_check.yml
+++ b/roles/set_locale/tasks/pre_check.yml
@@ -4,4 +4,6 @@
     that:
       - set_locale_keymap is defined and
         set_locale_keymap is string
+      - set_locale_system_locale is defined and
+        set_locale_system_locale is string
     fail_msg: "Require to fulfill the assert conditions to run the role"

--- a/roles/set_locale/tasks/pre_check.yml
+++ b/roles/set_locale/tasks/pre_check.yml
@@ -1,0 +1,7 @@
+---
+- name: Check arguments for running the role
+  ansible.builtin.assert:
+    that:
+      # - read_excel_data is defined and
+      #   read_excel_data is string
+    fail_msg: "Require to fulfill the assert conditions to run the role"

--- a/roles/set_locale/tasks/pre_check.yml
+++ b/roles/set_locale/tasks/pre_check.yml
@@ -2,6 +2,6 @@
 - name: Check arguments for running the role
   ansible.builtin.assert:
     that:
-      # - read_excel_data is defined and
-      #   read_excel_data is string
+      - set_locale_keymap is defined and
+        set_locale_keymap is string
     fail_msg: "Require to fulfill the assert conditions to run the role"

--- a/roles/set_locale/tasks/set_locale.yml
+++ b/roles/set_locale/tasks/set_locale.yml
@@ -25,6 +25,6 @@
   register: result_keymap_pre
 
 - name: Keymap Settings
-  ansible.builtin.command: localectl set-keymap jp106
+  ansible.builtin.command: localectl set-keymap {{ set_locale_keymap }}
   changed_when: true
-  when: "'jp106' not in result_keymap_pre.stdout"
+  when: set_locale_keymap not in result_keymap_pre.stdout

--- a/roles/set_locale/tasks/set_locale.yml
+++ b/roles/set_locale/tasks/set_locale.yml
@@ -1,0 +1,30 @@
+---
+- name: Install Japanese Language Pack
+  ansible.builtin.dnf:
+    name:
+      - glibc-langpack-ja
+    state: present
+
+- name: Check System Locale
+  ansible.builtin.shell: |
+    set -o pipefail
+    localectl status | grep "System Locale"
+  changed_when: false
+  register: result_locale_pre
+
+- name: Locale Settings
+  ansible.builtin.command: localectl set-locale LANG=ja_JP.utf8
+  changed_when: true
+  when: "'LANG=ja_JP.UTF-8' not in result_locale_pre.stdout"
+
+- name: Check Keymap
+  ansible.builtin.shell: |
+    set -o pipefail
+    localectl status | grep "VC Keymap"
+  changed_when: false
+  register: result_keymap_pre
+
+- name: Keymap Settings
+  ansible.builtin.command: localectl set-keymap jp106
+  changed_when: true
+  when: "'jp106' not in result_keymap_pre.stdout"

--- a/roles/set_locale/tasks/set_locale.yml
+++ b/roles/set_locale/tasks/set_locale.yml
@@ -13,9 +13,9 @@
   register: result_locale_pre
 
 - name: Locale Settings
-  ansible.builtin.command: localectl set-locale LANG=ja_JP.utf8
+  ansible.builtin.command: localectl set-locale LANG={{ set_locale_system_locale }}
   changed_when: true
-  when: "'LANG=ja_JP.UTF-8' not in result_locale_pre.stdout"
+  when: set_locale_system_locale not in result_locale_pre.stdout
 
 - name: Check Keymap
   ansible.builtin.shell: |

--- a/roles/set_locale/vars/main.yml
+++ b/roles/set_locale/vars/main.yml
@@ -1,2 +1,3 @@
 ---
 set_locale_keymap: jp106
+set_locale_system_locale: ja_JP.UTF-8

--- a/roles/set_locale/vars/main.yml
+++ b/roles/set_locale/vars/main.yml
@@ -1,0 +1,2 @@
+---
+set_locale_keymap: jp106


### PR DESCRIPTION
## 変更理由
ロケール設定を行うロールを作成するため

## 変更内容

- ロケール設定（ja_JP.UTF-8）を行うロールを新規作成
- Keymapをjp106に設定
- ロールを呼び出すPlaybookを新規作成